### PR TITLE
Update store configuration using configureStore in createSlice.mdx

### DIFF
--- a/docs/api/createSlice.mdx
+++ b/docs/api/createSlice.mdx
@@ -235,7 +235,7 @@ Result's function `getInitialState` provides access to the initial state value g
 ```ts
 import { createSlice, createAction } from '@reduxjs/toolkit'
 import type { PayloadAction } from '@reduxjs/toolkit'
-import { createStore, combineReducers } from 'redux'
+import { configureStore, combineReducers } from 'redux'
 
 const incrementBy = createAction<number>('incrementBy')
 const decrementBy = createAction<number>('decrementBy')
@@ -282,12 +282,12 @@ const user = createSlice({
   },
 })
 
-const reducer = combineReducers({
-  counter: counter.reducer,
-  user: user.reducer,
+const store = configureStore({
+  reducer: {
+    counter: counter.reducer,
+    user: user.reducer,
+  },
 })
-
-const store = createStore(reducer)
 
 store.dispatch(counter.actions.increment())
 // -> { counter: 1, user: {name : '', age: 21} }


### PR DESCRIPTION
This commit addresses the deprecation of createStore by updating the store configuration in createSlice.mdx to use the recommended configureStore method.